### PR TITLE
adding hybrid gateway failover e2e test to suit

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -159,8 +159,13 @@ complete (unless `SKIP_CLEANUP=true`).
 - **Hybrid → Cloud service**: ClusterIP service on cloud, reached from hybrid pod
 - **Cloud → Hybrid service**: ClusterIP service on hybrid, reached from cloud pod
 
-### Pending — Gateway Resilience
-- **Leader failover**: delete all gateway pods, verify standby recovers connectivity
+### Active — Gateway Resilience
+- **Leader failover**: identifies the current leader via the `hybrid-gateway-leader`
+  Lease, starts continuous bidirectional HTTP probes (cloud → hybrid and hybrid → cloud),
+  deletes only the leader pod, then verifies the standby acquires the lease and
+  re-programs route tables with no connectivity gap exceeding the acceptable threshold.
+  The maximum time between two consecutive successful probes is reported as the
+  failover downtime.
 
 ## Architecture
 
@@ -170,8 +175,9 @@ test/e2e/
 │   └── main.go                 # Orchestrator: sweeps, builds, configures run.E2E
 ├── testdata/
 │   └── cilium-template-1.19.0.yaml  # Pre-rendered Cilium 1.19.0 with VTEP enabled
-├── gateway_suite_test.go       # BeforeSuite: infra setup (nodes, MNGs, Cilium, SGs, gateway)
-├── gateway_test.go             # Ginkgo specs: connectivity, service discovery, failover
+├── gateway_suite_test.go       # SynchronizedBeforeSuite: infra setup (nodes, MNGs, Cilium, SGs, gateway)
+├── gateway_test.go             # Ginkgo specs: connectivity, service discovery, resilience
+├── helpers_test.go             # Reusable test helpers: leader election, connectivity monitor
 └── README.md
 ```
 

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -118,37 +118,99 @@ var _ = Describe("EKS Hybrid Nodes Gateway", func() {
 		})
 
 		Context("Gateway Resilience", func() {
-			It("should recover connectivity after leader pod is deleted", func(ctx context.Context) {
-				Skip("temporarily skipped - pending manual validation")
+			It("should maintain connectivity during leader failover", func(ctx context.Context) {
 				testCaseLabels["test-case"] = "leader-failover"
 
+				// 1. Deploy test pods — one on each side for bidirectional monitoring.
 				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
-				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-failover", testCaseLabels)
+				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-hybrid-fo", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred())
 
 				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
-				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "client-failover", testCaseLabels)
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "nginx-cloud-fo", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred())
 
-				test.Logger.Info("Verifying connectivity before failover")
-				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-failover", "nginx-failover", "default", test.Logger)
-				Expect(err).NotTo(HaveOccurred(), "pre-failover connectivity should work")
+				// 2. Verify baseline connectivity in both directions before starting monitors.
+				test.Logger.Info("Verifying baseline connectivity (cloud → hybrid)")
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "nginx-cloud-fo", "nginx-hybrid-fo", "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "baseline cloud → hybrid should work")
 
-				test.Logger.Info("Deleting gateway pods to trigger failover")
-				err = kubernetes.DeletePodsWithLabels(ctx, test.K8sClient.Interface, gatewayNamespace, "app.kubernetes.io/name=eks-hybrid-nodes-gateway", test.Logger)
+				test.Logger.Info("Verifying baseline connectivity (hybrid → cloud)")
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "nginx-hybrid-fo", "nginx-cloud-fo", "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "baseline hybrid → cloud should work")
+
+				// 3. Resolve pod IPs for the continuous monitors.
+				hybridPod, err := test.K8sClient.Interface.CoreV1().Pods("default").Get(ctx, "nginx-hybrid-fo", metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
+				hybridPodIP := hybridPod.Status.PodIP
 
+				cloudPod, err := test.K8sClient.Interface.CoreV1().Pods("default").Get(ctx, "nginx-cloud-fo", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				cloudPodIP := cloudPod.Status.PodIP
+
+				// 4. Identify the current leader via the Lease object.
+				leaderPodName := findLeaderPod(ctx, test)
+				test.Logger.Info("Identified leader pod", "name", leaderPodName)
+
+				// 5. Start continuous connectivity monitors in both directions.
+				test.Logger.Info("Starting continuous connectivity monitoring")
+				c2h := startConnectivityMonitor(ctx, test, "nginx-cloud-fo", hybridPodIP, "default", "cloud-to-hybrid")
+				h2c := startConnectivityMonitor(ctx, test, "nginx-hybrid-fo", cloudPodIP, "default", "hybrid-to-cloud")
+
+				// 5a. Wait for monitors to accumulate baseline successes. This
+				//     catches broken exec/curl setups before triggering failover
+				//     so the test fails with a clear message instead of silently
+				//     passing with zero probes.
+				minBaselineSuccesses := 5
+				Eventually(func() int { return c2h.successCount() }).
+					WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(BeNumerically(">=", minBaselineSuccesses), "cloud-to-hybrid monitor should record baseline successes")
+				Eventually(func() int { return h2c.successCount() }).
+					WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(BeNumerically(">=", minBaselineSuccesses), "hybrid-to-cloud monitor should record baseline successes")
+				test.Logger.Info("Baseline connectivity confirmed", "minSuccesses", minBaselineSuccesses)
+
+				// 6. Delete only the leader pod — the standby should acquire the
+				//    lease, re-program route tables and VTEP config, and resume
+				//    forwarding traffic with minimal interruption.
+				test.Logger.Info("Deleting leader pod to trigger failover", "leader", leaderPodName)
+				err = test.K8sClient.Interface.CoreV1().Pods(gatewayNamespace).Delete(ctx, leaderPodName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred(), "should delete leader pod")
+
+				// 7. Wait for all gateway pods to be running again.
 				test.Logger.Info("Waiting for gateway pods to recover")
 				err = kubernetes.WaitForPodsToBeRunning(ctx, test.K8sClient.Interface, metav1.ListOptions{
 					LabelSelector: "app.kubernetes.io/name=eks-hybrid-nodes-gateway",
 				}, gatewayNamespace, test.Logger)
 				Expect(err).NotTo(HaveOccurred(), "gateway pods should recover")
 
-				test.Logger.Info("Verifying connectivity after failover")
-				Eventually(func(g Gomega) {
-					err := kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-failover", "nginx-failover", "default", test.Logger)
-					g.Expect(err).NotTo(HaveOccurred())
-				}).WithTimeout(3*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "post-failover connectivity should recover")
+				// 8. Verify a different pod now holds the lease.
+				Eventually(func() (string, error) {
+					return getLeaderPodName(ctx, test)
+				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).ShouldNot(
+					Equal(leaderPodName), "a new leader should be elected after deleting %s", leaderPodName)
+
+				newLeader, _ := getLeaderPodName(ctx, test)
+				test.Logger.Info("New leader elected", "name", newLeader, "previousLeader", leaderPodName)
+
+				// Let post-failover pings accumulate to confirm stable recovery.
+				time.Sleep(30 * time.Second)
+
+				// 9. Stop monitors and analyse results.
+				c2hResults := c2h.stop()
+				h2cResults := h2c.stop()
+
+				test.Logger.Info("=== Failover Connectivity Analysis ===")
+				c2hMaxGap, err := analyzeConnectivity(c2hResults, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "cloud-to-hybrid analysis should have enough data points")
+				h2cMaxGap, err2 := analyzeConnectivity(h2cResults, test.Logger)
+				Expect(err2).NotTo(HaveOccurred(), "hybrid-to-cloud analysis should have enough data points")
+
+				// 10. Assert the maximum gap between two successful pings never
+				//     exceeded the acceptable failover threshold.
+				maxAcceptableGap := 30 * time.Second
+				Expect(c2hMaxGap).To(BeNumerically("<=", maxAcceptableGap),
+					"cloud-to-hybrid max gap should be ≤%s (was %s)", maxAcceptableGap, c2hMaxGap)
+				Expect(h2cMaxGap).To(BeNumerically("<=", maxAcceptableGap),
+					"hybrid-to-cloud max gap should be ≤%s (was %s)", maxAcceptableGap, h2cMaxGap)
 			})
 		})
 	})

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,220 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// probeInterval is the fixed cadence between connectivity probes. This keeps
+// exec call rate predictable and makes gap measurements consistent.
+const probeInterval = 500 * time.Millisecond
+
+// getLeaderPodName reads the controller-runtime Lease for the gateway's leader
+// election and resolves it to a running pod name. It returns an error rather
+// than failing via Gomega so callers like Eventually can retry on transient
+// states (e.g. lease briefly unowned during failover). Because the gateway
+// runs with hostNetwork: true, the holderIdentity is the node hostname rather
+// than the pod name, so we match via spec.nodeName.
+func getLeaderPodName(ctx context.Context, test *suite.PeeredVPCTest) (string, error) {
+	lease, err := test.K8sClient.Interface.CoordinationV1().Leases(gatewayNamespace).Get(
+		ctx, "hybrid-gateway-leader", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("reading lease: %w", err)
+	}
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+		return "", fmt.Errorf("lease has no holder")
+	}
+
+	holderIdentity := *lease.Spec.HolderIdentity
+
+	pods, err := test.K8sClient.Interface.CoreV1().Pods(gatewayNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=eks-hybrid-nodes-gateway",
+	})
+	if err != nil {
+		return "", fmt.Errorf("listing gateway pods: %w", err)
+	}
+
+	// controller-runtime encodes holderIdentity as "<hostname>_<uuid>".
+	// With hostNetwork the hostname is the node name, not the pod name.
+	for i := range pods.Items {
+		if strings.HasPrefix(holderIdentity, pods.Items[i].Spec.NodeName) {
+			return pods.Items[i].Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no running gateway pod matches leader identity %q", holderIdentity)
+}
+
+// findLeaderPod resolves the current leader pod name, failing the test
+// immediately if the lease cannot be read or matched to a running pod.
+func findLeaderPod(ctx context.Context, test *suite.PeeredVPCTest) string {
+	name, err := getLeaderPodName(ctx, test)
+	Expect(err).NotTo(HaveOccurred(), "should find leader pod")
+	return name
+}
+
+// pingResult captures the outcome of a single HTTP probe.
+type pingResult struct {
+	timestamp time.Time
+	success   bool
+	direction string
+}
+
+// connectivityMonitor continuously probes an HTTP endpoint from inside a
+// Kubernetes pod and records the result of every attempt. Probes run at a
+// fixed interval to keep API server load predictable and make gap
+// measurements consistent. It is safe for concurrent use.
+type connectivityMonitor struct {
+	mu      sync.Mutex
+	results []pingResult
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// startConnectivityMonitor launches a background goroutine that executes
+// curl inside clientPod, targeting the given IP on port 80. Each probe uses
+// a 1 s connect timeout and 2 s total timeout. The command is wrapped with
+// "|| true" so the shell always exits 0, preventing ExecPodWithRetries from
+// retrying on curl-level failures; we distinguish success from failure by
+// inspecting the HTTP status code written to stdout.
+//
+// Probes run at a fixed interval (probeInterval) to avoid hammering the API
+// server with exec calls and to produce consistent timing measurements.
+func startConnectivityMonitor(
+	ctx context.Context,
+	test *suite.PeeredVPCTest,
+	clientPod, targetIP, namespace, direction string,
+) *connectivityMonitor {
+	monCtx, cancel := context.WithCancel(ctx)
+	m := &connectivityMonitor{
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	curlCmd := fmt.Sprintf(
+		"curl -s -o /dev/null -w '%%{http_code}' http://%s:80 --connect-timeout 1 --max-time 2 || true",
+		targetIP)
+
+	go func() {
+		defer close(m.done)
+		ticker := time.NewTicker(probeInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-monCtx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			stdout, _, err := kubernetes.ExecPodWithRetries(
+				monCtx, test.K8sClientConfig, test.K8sClient.Interface,
+				clientPod, namespace, "sh", "-c", curlCmd)
+
+			if monCtx.Err() != nil {
+				return
+			}
+
+			success := err == nil && strings.TrimSpace(stdout) == "200"
+			m.mu.Lock()
+			m.results = append(m.results, pingResult{
+				timestamp: time.Now(),
+				success:   success,
+				direction: direction,
+			})
+			m.mu.Unlock()
+		}
+	}()
+
+	return m
+}
+
+// stop signals the monitor goroutine to exit, waits for it to finish, and
+// returns a snapshot of all collected results.
+func (m *connectivityMonitor) stop() []pingResult {
+	m.cancel()
+	<-m.done
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]pingResult, len(m.results))
+	copy(out, m.results)
+	return out
+}
+
+// successCount returns the number of successful probes recorded so far.
+// It is safe to call while the monitor is still running.
+func (m *connectivityMonitor) successCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, r := range m.results {
+		if r.success {
+			n++
+		}
+	}
+	return n
+}
+
+// analyzeConnectivity computes the maximum elapsed time between two
+// consecutive successful probes and logs a summary. It returns an error if
+// fewer than 2 successful probes were recorded, since gap calculation
+// requires at least two data points and zero successes would otherwise
+// silently report zero downtime.
+func analyzeConnectivity(results []pingResult, logger logr.Logger) (time.Duration, error) {
+	if len(results) == 0 {
+		return 0, fmt.Errorf("no connectivity results to analyze")
+	}
+
+	total := len(results)
+	successCount := 0
+	for _, r := range results {
+		if r.success {
+			successCount++
+		}
+	}
+
+	if successCount < 2 {
+		logger.Info("Connectivity results",
+			"direction", results[0].direction,
+			"total", total,
+			"successes", successCount,
+			"successRate", "0.0%",
+		)
+		return 0, fmt.Errorf("fewer than 2 successful probes (%d/%d); cannot compute gap — connectivity may be fully broken", successCount, total)
+	}
+
+	var maxGap time.Duration
+	var lastSuccess time.Time
+	for _, r := range results {
+		if r.success {
+			if !lastSuccess.IsZero() {
+				if gap := r.timestamp.Sub(lastSuccess); gap > maxGap {
+					maxGap = gap
+				}
+			}
+			lastSuccess = r.timestamp
+		}
+	}
+
+	failures := total - successCount
+	logger.Info("Connectivity results",
+		"direction", results[0].direction,
+		"total", total,
+		"failures", failures,
+		"successRate", fmt.Sprintf("%.1f%%", float64(successCount)/float64(total)*100),
+		"maxGap", maxGap.String(),
+	)
+
+	return maxGap, nil
+}


### PR DESCRIPTION
## Description of changes:
Adding an e2e test to test gateway failover scenario.

## Testing
```bash
------------------------------
EKS Hybrid Nodes Gateway when gateway is deployed with hybrid and cloud nodes Gateway Resilience should maintain connectivity during leader failover
/Users/ramaliar/Amazon/eks-hybrid-nodes-gateway/test/e2e/gateway_test.go:121
2026-04-08T16:58:37.049-0700	INFO	Found node with label	{"labelKey": "eks.amazonaws.com/compute-type", "labelValue": "hybrid", "nodeName": "mi-0fffb6335db451aa3"}
2026-04-08T16:58:42.136-0700	INFO	Found node with label	{"labelKey": "node.kubernetes.io/instance-type", "labelValue": "t3.medium", "nodeName": "ip-10-20-1-156.us-west-2.compute.internal"}
2026-04-08T16:58:47.200-0700	INFO	Verifying baseline connectivity (cloud → hybrid)
2026-04-08T16:58:47.219-0700	INFO	Testing pod-to-pod connectivity	{"from": "nginx-cloud-fo", "to": "nginx-hybrid-fo", "ip": "10.87.0.240"}
2026-04-08T16:58:47.440-0700	INFO	Pod-to-pod connectivity successful	{"from": "nginx-cloud-fo", "to": "nginx-hybrid-fo"}
2026-04-08T16:58:47.440-0700	INFO	Verifying baseline connectivity (hybrid → cloud)
2026-04-08T16:58:47.457-0700	INFO	Testing pod-to-pod connectivity	{"from": "nginx-hybrid-fo", "to": "nginx-cloud-fo", "ip": "10.20.1.250"}
2026-04-08T16:58:47.634-0700	INFO	Pod-to-pod connectivity successful	{"from": "nginx-hybrid-fo", "to": "nginx-cloud-fo"}
2026-04-08T16:58:47.711-0700	INFO	Identified leader pod	{"name": "eks-hybrid-nodes-gateway-8575f49bb7-4w4ml"}
2026-04-08T16:58:47.711-0700	INFO	Starting continuous connectivity monitoring
2026-04-08T16:58:57.711-0700	INFO	Deleting leader pod to trigger failover	{"leader": "eks-hybrid-nodes-gateway-8575f49bb7-4w4ml"}
2026-04-08T16:58:57.733-0700	INFO	Waiting for gateway pods to recover
2026-04-08T16:58:59.873-0700	INFO	New leader elected	{"name": "eks-hybrid-nodes-gateway-8575f49bb7-5k8nf", "previousLeader": "eks-hybrid-nodes-gateway-8575f49bb7-4w4ml"}
2026-04-08T16:59:30.537-0700	INFO	=== Failover Connectivity Analysis ===
2026-04-08T16:59:30.537-0700	INFO	Connectivity results	{"direction": "cloud-to-hybrid", "total": 201, "failures": 4, "successRate": "98.0%", "maxGap": "3.844317667s"}
2026-04-08T16:59:30.537-0700	INFO	Connectivity results	{"direction": "hybrid-to-cloud", "total": 227, "failures": 4, "successRate": "98.2%", "maxGap": "3.777939667s"}
2026-04-08T16:59:30.537-0700	INFO	Cleaning up test resources
2026-04-08T16:59:30.586-0700	INFO	Force deleted pod	{"name": "nginx-cloud-fo"}
2026-04-08T16:59:30.621-0700	INFO	Force deleted pod	{"name": "nginx-hybrid-fo"}
.
.
.
[ReportAfterSuite] PASSED [0.009 seconds]
------------------------------

Ran 3 of 5 Specs in 810.087 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 2 Skipped
PASS

Ginkgo ran 1 suite in 13m32.093904417s
Test Suite Passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
