### PR TITLE
adding buildspec for running prod release

### DIFF
--- a/buildspecs/prod-release.yml
+++ b/buildspecs/prod-release.yml
@@ -1,0 +1,14 @@
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - echo "Fetching GitHub token from Secrets Manager..."
+      - export GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id github-hybrid-gateway-token --query 'SecretString' --output text | jq -r '.["github-token"]')
+      - echo "Checking out release tag ${RELEASE_TAG}..."
+      - git init
+      - git remote add origin https://${GITHUB_TOKEN}@github.com/aws/eks-hybrid-nodes-gateway.git
+      - git fetch --depth 1 origin tag ${RELEASE_TAG}
+      - git checkout -f ${RELEASE_TAG}
+  build:
+    commands:
+      - ./hack/prod-release.sh

--- a/hack/prod-release.sh
+++ b/hack/prod-release.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# ---------------------------------------------------------------------------
+# prod-release.sh — Promote a staging image + Helm chart to ECR Public.
+#
+# Prerequisites (handled by buildspecs/prod-release.yml pre_build phase):
+#   The working directory has been checked out at the RELEASE_TAG commit.
+#
+# Expected environment variables (set by CDK / CodePipeline):
+#   RELEASE_TAG        – semver tag, e.g. v1.0.0 (pipeline variable)
+#   STAGING_ECR_URI    – private staging repo URI
+#   PUBLIC_ECR_URI     – public ECR repo URI
+#   ECR_REPO           – repo name (eks-hybrid-nodes-gateway)
+#   AWS_ACCOUNT_ID     – staging account ID
+#   AWS_DEFAULT_REGION – staging region
+# ---------------------------------------------------------------------------
+
+# ── 1. Validate inputs ─────────────────────────────────────────────────────
+
+if [[ -z "${RELEASE_TAG:-}" ]]; then
+  echo "ERROR: RELEASE_TAG is not set. Pass it as a pipeline variable." >&2
+  exit 1
+fi
+
+echo "==> Starting release for ${RELEASE_TAG}"
+
+# ── 2. Resolve commit SHA → IMAGE_TAG ─────────────────────────────────────
+# The pre_build phase already checked out the repo at the release tag, so
+# HEAD is the tagged commit. The first 8 characters match the staging image
+# tag convention used by the build pipeline.
+
+COMMIT_SHA=$(git rev-parse HEAD)
+IMAGE_TAG="${COMMIT_SHA:0:8}"
+
+echo "    ${RELEASE_TAG} → commit ${COMMIT_SHA} → image tag ${IMAGE_TAG}"
+
+# ── 3. Login to private staging ECR ────────────────────────────────────────
+
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+
+echo "==> Logging in to staging ECR (${ECR_REGISTRY})"
+aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" \
+  | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+# ── 4. Login to ECR Public ─────────────────────────────────────────────────
+
+echo "==> Logging in to ECR Public"
+aws ecr-public get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin public.ecr.aws
+
+# ── 5. Copy multi-arch container image to ECR Public ──────────────────────
+# Use skopeo to do a registry-to-registry copy that preserves the full
+# multi-arch manifest list (linux/amd64 + linux/arm64).
+
+STAGING_IMAGE="${STAGING_ECR_URI}:${IMAGE_TAG}"
+PUBLIC_IMAGE="${PUBLIC_ECR_URI}:${RELEASE_TAG}"
+
+SKOPEO_POLICY="$(mktemp)"
+trap 'rm -f "${SKOPEO_POLICY}"' EXIT
+cat > "${SKOPEO_POLICY}" <<'EOF'
+{ "default": [{ "type": "insecureAcceptAnything" }] }
+EOF
+
+echo "==> Copying ${STAGING_IMAGE} → ${PUBLIC_IMAGE} (multi-arch)"
+skopeo copy --policy "${SKOPEO_POLICY}" --all \
+  "docker://${STAGING_IMAGE}" \
+  "docker://${PUBLIC_IMAGE}"
+
+# ── 6. Package and push Helm chart to ECR Public ───────────────────────────
+# Strip the leading 'v' for semver compliance (v1.0.0 → 1.0.0).
+# helm push expects the OCI registry path without the chart name, e.g.
+# oci://public.ecr.aws/i7k6m1j7/eks — so we strip the trailing repo name.
+
+CHART_VERSION="${RELEASE_TAG#v}"
+CHART_OCI_REPO="oci://$(dirname "${PUBLIC_ECR_URI}")"
+
+echo "==> Packaging Helm chart (version=${CHART_VERSION}, appVersion=${RELEASE_TAG})"
+make helm-push \
+  CHART_REPO="${CHART_OCI_REPO}" \
+  CHART_VERSION="${CHART_VERSION}" \
+  APP_VERSION="${RELEASE_TAG}"
+
+echo "==> Release ${RELEASE_TAG} complete"
+echo "    Image: ${PUBLIC_IMAGE}"
+echo "    Chart: ${CHART_OCI_REPO}/${ECR_REPO}:${CHART_VERSION}"


### PR DESCRIPTION
## Production Release Buildspec

### Summary

Adds the CodeBuild buildspec and release script for publishing EKS Hybrid Nodes Gateway container images and Helm charts to ECR Public.

### How it works

An operator tags a commit and triggers the release pipeline manually:

```bash
git tag v1.0.0 && git push origin v1.0.0

aws codepipeline start-pipeline-execution \
  --name eks-hybrid-gateway-release \
  --variables name=RELEASE_TAG,value=v1.0.0
```

The script then:

1. **Resolves the tag to a commit SHA via the GitHub API** — The pipeline source stage downloads a zip with no `.git` directory, so we query the GitHub refs API using the token stored in Secrets Manager (`github-hybrid-gateway-token`). Annotated tags are dereferenced to the underlying commit. The first 8 characters of the SHA become the `IMAGE_TAG`, matching the convention used by the build pipeline.

2. **Copies the multi-arch container image to ECR Public** — Uses `skopeo copy --all` for a registry-to-registry copy that preserves the full manifest list (linux/amd64 + linux/arm64). A plain `docker pull/tag/push` would flatten to a single platform. The image is retagged from the staging SHA tag to the release tag (e.g. `a2792242` → `v1.0.0`).

3. **Packages and pushes the Helm chart to ECR Public** — The chart version is derived from the release tag with the `v` prefix stripped for semver compliance (e.g. `v1.0.0` → `1.0.0`). The OCI registry path is derived from the `PUBLIC_ECR_URI` environment variable.

### Safety

The release pipeline only promotes images that were already built and E2E-tested by the build pipeline on merge to main. No compilation or testing happens during release — if the tagged commit was never built, the staging image won't exist and the script fails at the `skopeo copy` step.

### Testing

Successfully ran the full release pipeline end-to-end in the staging account, publishing a `v1.0.0-rc.1` image and chart to ECR Public.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
