### PR TITLE
fix: passing in REGISTRY as its required for helm push

### DIFF
--- a/hack/build-gateway.sh
+++ b/hack/build-gateway.sh
@@ -57,6 +57,7 @@ make helm-lint
 
 echo "Packaging and pushing Helm chart..."
 make helm-push \
+  REGISTRY="${ECR_REGISTRY}" \
   CHART_REPO="oci://${ECR_REGISTRY}" \
   CHART_VERSION="0.0.0-${IMAGE_TAG}" \
   APP_VERSION="${IMAGE_TAG}"


### PR DESCRIPTION
*Description of changes:*
Fixing failure in build script

```
Packaging and pushing Helm chart...
helm package charts/eks-hybrid-nodes-gateway --version 0.0.0-9b71ad16 --app-version 9b71ad16
Successfully packaged chart and saved it to: /codebuild/output/src2467044347/src/eks-hybrid-nodes-gateway-0.0.0-9b71ad16.tgz
error: REGISTRY is required
make: *** [Makefile:75: helm-push] Error 1
[Container] 2026/04/15 16:44:46.534458 Command did not exit successfully ./hack/build-gateway.sh $CODEBUILD_RESOLVED_SOURCE_VERSION exit status 2
[Container] 2026/04/15 16:44:46.539986 Phase complete: BUILD State: FAILED
[Container] 2026/04/15 16:44:46.540007 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: ./hack/build-gateway.sh $CODEBUILD_RESOLVED_SOURCE_VERSION. Reason: exit status 2
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
