### PR TITLE
Add E2E test cases for helm upgrade, webhooks, and node joins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ ginkgo: ## Install ginkgo binary (pinned to module version)
 		(echo "Installing ginkgo $(GINKGO_VERSION)..." && \
 		 GOBIN=$(GOBIN) CGO_ENABLED=0 go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION))
 
-K8S_VERSION    ?= 1.31
+K8S_VERSION    ?= 1.35
 AWS_REGION     ?= us-west-2
 E2E_TIMEOUT    ?= 60m
 SKIP_CLEANUP   ?= false

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/vishvananda/netlink v1.3.2-0.20260109214200-c6faf428e8f8
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.20.1
+	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
 	sigs.k8s.io/controller-runtime v0.22.4
@@ -216,7 +217,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect
 	k8s.io/cli-runtime v0.35.1 // indirect

--- a/test/e2e/gateway_suite_test.go
+++ b/test/e2e/gateway_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"text/template"
@@ -42,15 +43,16 @@ import (
 const gatewayPolicyName = "eks-hybrid-gateway-e2e"
 
 const (
-	gatewayNamespace          = "eks-hybrid-nodes-gateway"
-	gatewayReleaseName        = "eks-hybrid-nodes-gateway"
-	gatewayNodeLabel          = "hybrid-gateway-node"
-	vxlanPort                 = 8472
-	cloudInstanceType         = "t3.medium"
-	gatewayInstanceType       = "t3.large"
-	httpPort            int32 = 80
-
-	crossVPCPropagationWait = 180 * time.Second
+	gatewayNamespace              = "eks-hybrid-nodes-gateway"
+	gatewayReleaseName            = "eks-hybrid-nodes-gateway"
+	gatewayNodeLabel              = "hybrid-gateway-node"
+	vxlanPort                     = 8472
+	cloudInstanceType             = "t3.medium"
+	gatewayInstanceType           = "t3.large"
+	httpPort                int32 = 80
+	cloudVPCCIDR                  = "10.20.0.0/16"
+	hybridVPCCIDR                 = "10.80.0.0/16"
+	crossVPCPropagationWait       = 30 * time.Second
 )
 
 // Cilium 1.19.0 template pre-rendered with our custom values (VTEP, l7proxy, etc.).
@@ -109,6 +111,8 @@ var _ = SynchronizedBeforeSuite(
 
 		test.Logger.Info("Cleaning up resources from previous runs")
 		cleanupTestResources(ctx, test, gatewayLabels)
+		// Also clean up webhook resources (namespace + cluster-scoped webhook config) from previous runs.
+		cleanupWebhookTest(ctx, test)
 
 		// 1. Create 1 hybrid node (on-prem side).
 		hybridNode := suite.NodeCreate{
@@ -144,12 +148,12 @@ var _ = SynchronizedBeforeSuite(
 		// 4b. Allow VXLAN (UDP 8472) ingress on the cluster security group.
 		clusterSG := getClusterSecurityGroup(ctx, test)
 		test.Logger.Info("Allowing VXLAN ingress on cluster security group", "sgID", clusterSG)
-		allowVXLANIngress(ctx, test, clusterSG)
+		allowVXLANIngress(ctx, test, clusterSG, hybridVPCCIDR)
 
 		// 4c. Allow VXLAN ingress on the hybrid node security group (return path).
 		hybridSG := test.Cluster.SecurityGroupID
 		test.Logger.Info("Allowing VXLAN ingress on hybrid node security group", "sgID", hybridSG)
-		allowVXLANIngress(ctx, test, hybridSG)
+		allowVXLANIngress(ctx, test, hybridSG, cloudVPCCIDR)
 
 		// 5. Attach EC2 route table permissions to the MNG node role.
 		test.Logger.Info("Attaching gateway IAM policy to MNG role")
@@ -184,7 +188,7 @@ var _ = SynchronizedBeforeSuite(
 			GatewayLabels:   gatewayLabels,
 			HybridNodeName:  hybridNodeName,
 			TestRunID:       testRunID,
-			VpcCIDR:         "10.20.0.0/16",
+			VpcCIDR:         cloudVPCCIDR,
 			PodCIDR:         "10.87.0.0/16",
 			GatewayImageURI: gatewayImageURI,
 			RouteTableIDs:   routeTableIDs,
@@ -312,8 +316,9 @@ func extractInstanceID(providerID string) string {
 	return parts[len(parts)-1]
 }
 
-// installGatewayChart pulls the chart from an OCI registry and installs it.
-func installGatewayChart(ctx context.Context, test *suite.PeeredVPCTest, chartURI, chartVersion, imageURI, routeTableIDs string) {
+// newHelmConfig creates a Helm action configuration authenticated to the ECR
+// registry hosting the chart. Used by both install and upgrade.
+func newHelmConfig(ctx context.Context, test *suite.PeeredVPCTest, chartURI string) (*action.Configuration, *cli.EnvSettings) {
 	settings := cli.New()
 	settings.KubeConfig = fmt.Sprintf("/tmp/%s.kubeconfig", test.Cluster.Name)
 	cfg := new(action.Configuration)
@@ -331,7 +336,24 @@ func installGatewayChart(ctx context.Context, test *suite.PeeredVPCTest, chartUR
 	Expect(err).NotTo(HaveOccurred(), "should login to ECR registry %s", ecrHost)
 
 	cfg.RegistryClient = regClient
+	return cfg, settings
+}
 
+func gatewayHelmValues(imageURI, podCIDRs, routeTableIDs string) map[string]interface{} {
+	repo, tag := splitImage(imageURI)
+	return map[string]interface{}{
+		"image":           map[string]interface{}{"repository": repo, "tag": tag},
+		"vpcCIDR":         cloudVPCCIDR,
+		"podCIDRs":        podCIDRs,
+		"routeTableIDs":   routeTableIDs,
+		"createNamespace": false,
+		"autoMode":        map[string]interface{}{"enabled": false},
+	}
+}
+
+// installGatewayChart pulls the chart from an OCI registry and installs it.
+func installGatewayChart(ctx context.Context, test *suite.PeeredVPCTest, chartURI, chartVersion, imageURI, routeTableIDs string) {
+	cfg, settings := newHelmConfig(ctx, test, chartURI)
 	install := action.NewInstall(cfg)
 	install.Namespace = gatewayNamespace
 	install.ReleaseName = gatewayReleaseName
@@ -347,22 +369,7 @@ func installGatewayChart(ctx context.Context, test *suite.PeeredVPCTest, chartUR
 	chart, err := loader.Load(chartPath)
 	Expect(err).NotTo(HaveOccurred(), "should load chart from %s", chartPath)
 
-	repo, tag := splitImage(imageURI)
-	vals := map[string]interface{}{
-		"image": map[string]interface{}{
-			"repository": repo,
-			"tag":        tag,
-		},
-		"vpcCIDR":         "10.20.0.0/16",
-		"podCIDRs":        "10.87.0.0/16",
-		"routeTableIDs":   routeTableIDs,
-		"createNamespace": false,
-		"autoMode": map[string]interface{}{
-			"enabled": false,
-		},
-	}
-
-	_, err = install.RunWithContext(ctx, chart, vals)
+	_, err = install.RunWithContext(ctx, chart, gatewayHelmValues(imageURI, "10.87.0.0/16", routeTableIDs))
 	Expect(err).NotTo(HaveOccurred(), "helm install should succeed")
 }
 
@@ -419,6 +426,7 @@ func labelsToSelector(labels map[string]string) string {
 	for k, v := range labels {
 		parts = append(parts, k+"="+v)
 	}
+	sort.Strings(parts)
 	return strings.Join(parts, ",")
 }
 
@@ -505,8 +513,9 @@ func getClusterSecurityGroup(ctx context.Context, test *suite.PeeredVPCTest) str
 }
 
 // allowVXLANIngress adds an ingress rule for VXLAN (UDP 8472) on the given security group.
-// The rule is not cleaned up because the security group is deleted with the cluster.
-func allowVXLANIngress(ctx context.Context, test *suite.PeeredVPCTest, sgID string) {
+// sourceCIDR scopes the rule to the VPC that originates VXLAN traffic.
+// The rule is idempotent — duplicate rules are silently ignored.
+func allowVXLANIngress(ctx context.Context, test *suite.PeeredVPCTest, sgID, sourceCIDR string) {
 	_, err := test.EC2Client.AuthorizeSecurityGroupIngress(ctx, &ec2v2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String(sgID),
 		IpPermissions: []ec2v2types.IpPermission{
@@ -515,14 +524,15 @@ func allowVXLANIngress(ctx context.Context, test *suite.PeeredVPCTest, sgID stri
 				FromPort:   aws.Int32(vxlanPort),
 				ToPort:     aws.Int32(vxlanPort),
 				IpRanges: []ec2v2types.IpRange{
-					// TODO (pokearu): Scope to exact CIDR
-					{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("VXLAN from hybrid nodes")},
+					{CidrIp: aws.String(sourceCIDR), Description: aws.String("VXLAN tunnel traffic")},
 				},
 			},
 		},
 	})
-	Expect(err).NotTo(HaveOccurred(), "should allow VXLAN ingress on security group %s", sgID)
-	test.Logger.Info("Added VXLAN ingress rule", "sgID", sgID, "port", vxlanPort)
+	if err != nil && !strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
+		Expect(err).NotTo(HaveOccurred(), "should allow VXLAN ingress on security group %s", sgID)
+	}
+	test.Logger.Info("VXLAN ingress rule ensured", "sgID", sgID, "port", vxlanPort, "sourceCIDR", sourceCIDR)
 }
 
 // roleNameFromARN extracts the role name from an IAM role ARN.
@@ -558,15 +568,32 @@ func upgradeCilium(ctx context.Context, test *suite.PeeredVPCTest) {
 	Expect(err).NotTo(HaveOccurred(), "should apply Cilium template")
 
 	test.Logger.Info("Waiting for cilium DaemonSet to be ready")
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
 		ds, err := test.K8sClient.Interface.AppsV1().DaemonSets("kube-system").Get(ctx, "cilium", metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		return ds.Status.DesiredNumberScheduled > 0 &&
-			ds.Status.DesiredNumberScheduled == ds.Status.NumberReady &&
-			ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled
-	}, 3*time.Minute, 5*time.Second).Should(BeTrue(), "cilium DaemonSet should become ready")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ds.Status.DesiredNumberScheduled).To(BeNumerically(">", 0))
+		g.Expect(ds.Status.NumberReady).To(Equal(ds.Status.DesiredNumberScheduled))
+		g.Expect(ds.Status.UpdatedNumberScheduled).To(Equal(ds.Status.DesiredNumberScheduled))
+	}).WithTimeout(3*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "cilium DaemonSet should become ready")
 
 	test.Logger.Info("Cilium upgraded successfully")
+}
+
+// upgradeGatewayChart performs a helm upgrade of the gateway release.
+func upgradeGatewayChart(ctx context.Context, test *suite.PeeredVPCTest, chartURI, chartVersion, imageURI, routeTableIDs, podCIDRs string) {
+	cfg, settings := newHelmConfig(ctx, test, chartURI)
+	upgrade := action.NewUpgrade(cfg)
+	upgrade.Namespace = gatewayNamespace
+	upgrade.Wait = true
+	upgrade.Timeout = 5 * time.Minute
+	upgrade.Version = chartVersion
+
+	chartPath, err := upgrade.LocateChart(chartURI, settings)
+	Expect(err).NotTo(HaveOccurred(), "should locate chart from OCI registry: %s:%s", chartURI, chartVersion)
+
+	chart, err := loader.Load(chartPath)
+	Expect(err).NotTo(HaveOccurred(), "should load chart from %s", chartPath)
+
+	_, err = upgrade.RunWithContext(ctx, gatewayReleaseName, chart, gatewayHelmValues(imageURI, podCIDRs, routeTableIDs))
+	Expect(err).NotTo(HaveOccurred(), "helm upgrade should succeed")
 }

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -4,13 +4,19 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"time"
 
+	"github.com/aws/eks-hybrid/test/e2e"
+	"github.com/aws/eks-hybrid/test/e2e/credentials"
 	"github.com/aws/eks-hybrid/test/e2e/kubernetes"
+	osystem "github.com/aws/eks-hybrid/test/e2e/os"
 	"github.com/aws/eks-hybrid/test/e2e/suite"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,11 +41,13 @@ var _ = Describe("EKS Hybrid Nodes Gateway", func() {
 			It("should route traffic from hybrid node pods to cloud node pods", func(ctx context.Context) {
 				testCaseLabels["test-case"] = "pod-hybrid-to-cloud"
 
-				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
-				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "nginx-cloud", testCaseLabels)
+				cloudNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find cloud node")
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "nginx-cloud", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred(), "should create nginx pod on cloud node %s", cloudNodeName)
 
-				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+				hybridNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find hybrid node")
 				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "client-hybrid", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred(), "should create client pod on hybrid node %s", hybridNodeName)
 
@@ -51,11 +59,13 @@ var _ = Describe("EKS Hybrid Nodes Gateway", func() {
 			It("should route traffic from cloud node pods to hybrid node pods", func(ctx context.Context) {
 				testCaseLabels["test-case"] = "pod-cloud-to-hybrid"
 
-				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
-				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-hybrid", testCaseLabels)
+				hybridNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find hybrid node")
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-hybrid", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred(), "should create nginx pod on hybrid node %s", hybridNodeName)
 
-				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				cloudNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find cloud node")
 				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "client-cloud", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred(), "should create client pod on cloud node %s", cloudNodeName)
 
@@ -122,11 +132,13 @@ var _ = Describe("EKS Hybrid Nodes Gateway", func() {
 				testCaseLabels["test-case"] = "leader-failover"
 
 				// 1. Deploy test pods — one on each side for bidirectional monitoring.
-				hybridNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
-				err := kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-hybrid-fo", testCaseLabels)
+				hybridNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find hybrid node")
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-hybrid-fo", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred())
 
-				cloudNodeName, _ := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				cloudNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find cloud node")
 				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "nginx-cloud-fo", testCaseLabels)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -188,7 +200,8 @@ var _ = Describe("EKS Hybrid Nodes Gateway", func() {
 				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).ShouldNot(
 					Equal(leaderPodName), "a new leader should be elected after deleting %s", leaderPodName)
 
-				newLeader, _ := getLeaderPodName(ctx, test)
+				newLeader, err := getLeaderPodName(ctx, test)
+				Expect(err).NotTo(HaveOccurred(), "should get new leader pod name")
 				test.Logger.Info("New leader elected", "name", newLeader, "previousLeader", leaderPodName)
 
 				// Let post-failover pings accumulate to confirm stable recovery.
@@ -211,6 +224,164 @@ var _ = Describe("EKS Hybrid Nodes Gateway", func() {
 					"cloud-to-hybrid max gap should be ≤%s (was %s)", maxAcceptableGap, c2hMaxGap)
 				Expect(h2cMaxGap).To(BeNumerically("<=", maxAcceptableGap),
 					"hybrid-to-cloud max gap should be ≤%s (was %s)", maxAcceptableGap, h2cMaxGap)
+			})
+		})
+
+		Context("Dynamic Node Lifecycle", func() {
+			It("should route traffic to a newly joined hybrid node", func(ctx context.Context) {
+				testCaseLabels["test-case"] = "dynamic-node-lifecycle"
+
+				hybridNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find hybrid node")
+				cloudNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find cloud node")
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-baseline", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred())
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "client-dynamic", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred())
+
+				test.Logger.Info("Verifying baseline connectivity before node join")
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-dynamic", "nginx-baseline", "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "baseline connectivity should work")
+
+				newNodeName := fmt.Sprintf("gateway-dynamic-%s", sharedTestData.TestRunID)
+				ssmProvider := &credentials.SsmProvider{
+					SSM:  test.SSMClient,
+					Role: test.StackOut.SSMNodeRoleName,
+				}
+				newNode := suite.NodeCreate{
+					InstanceName: newNodeName,
+					InstanceSize: e2e.Large,
+					NodeName:     newNodeName,
+					OS:           osystem.NewUbuntu2204AMD(),
+					Provider:     ssmProvider,
+					ComputeType:  e2e.CPUInstance,
+				}
+
+				test.Logger.Info("Joining second hybrid node dynamically", "name", newNodeName)
+				suite.CreateNodes(ctx, test, []suite.NodeCreate{newNode})
+
+				nodes, err := test.K8sClient.Interface.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+					LabelSelector: "eks.amazonaws.com/compute-type=hybrid",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nodes.Items).To(HaveLen(2), "expected exactly 2 hybrid nodes (original + dynamic)")
+				var dynamicNodeK8sName string
+				for _, n := range nodes.Items {
+					if n.Name != hybridNodeName {
+						dynamicNodeK8sName = n.Name
+					}
+				}
+				Expect(dynamicNodeK8sName).NotTo(BeEmpty(), "should find dynamically joined node")
+
+				DeferCleanup(func(ctx context.Context) {
+					if dynamicNodeK8sName != "" {
+						_ = test.K8sClient.Interface.CoreV1().Nodes().Delete(ctx, dynamicNodeK8sName, metav1.DeleteOptions{})
+					}
+				})
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, dynamicNodeK8sName, "default", test.Cluster.Region, test.Logger, "nginx-dynamic", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred(), "should create pod on dynamically joined node")
+
+				test.Logger.Info("Testing connectivity to pod on dynamically joined node")
+				Eventually(func(g Gomega) {
+					err := kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-dynamic", "nginx-dynamic", "default", test.Logger)
+					g.Expect(err).NotTo(HaveOccurred())
+				}).WithTimeout(3*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "should reach pod on dynamically joined node")
+
+				test.Logger.Info("Verifying original hybrid node not disrupted by join")
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-dynamic", "nginx-baseline", "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "original hybrid should still be reachable after node join")
+
+				test.Logger.Info("Deleting pods on dynamic node before removal")
+				_ = kubernetes.DeletePodsWithLabels(ctx, test.K8sClient.Interface, "default", "test-case=dynamic-node-lifecycle", test.Logger)
+
+				test.Logger.Info("Removing dynamically joined node", "name", newNodeName)
+				err = test.K8sClient.Interface.CoreV1().Nodes().Delete(ctx, dynamicNodeK8sName, metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred(), "should delete dynamic node")
+
+				test.Logger.Info("Waiting for node deletion to propagate")
+				Eventually(func(g Gomega) {
+					_, err := test.K8sClient.Interface.CoreV1().Nodes().Get(ctx, dynamicNodeK8sName, metav1.GetOptions{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "dynamic node should be gone, got: %v", err)
+				}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-post-remove", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred())
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "client-post-remove", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred())
+
+				test.Logger.Info("Verifying connectivity after dynamic node removal")
+				Eventually(func(g Gomega) {
+					err := kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-post-remove", "nginx-post-remove", "default", test.Logger)
+					g.Expect(err).NotTo(HaveOccurred())
+				}).WithTimeout(3*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "original hybrid should still work after dynamic node removal")
+			})
+		})
+
+		Context("Webhook Connectivity", func() {
+			It("should support admission webhook calls to pods on hybrid nodes through gateway", func(ctx context.Context) {
+				testCaseLabels["test-case"] = "webhook-connectivity"
+
+				test.Logger.Info("Deploying webhook server on hybrid node")
+				DeferCleanup(func(ctx context.Context) {
+					cleanupWebhookTest(ctx, test)
+				})
+				caPEM := deployWebhookOnHybridNode(ctx, test)
+
+				test.Logger.Info("Registering validating webhook")
+				registerValidatingWebhook(ctx, test, caPEM)
+
+				test.Logger.Info("Triggering webhook by creating a ConfigMap")
+				triggerCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: "webhook-trigger", Namespace: webhookTestNamespace},
+				}
+				_, err := test.K8sClient.Interface.CoreV1().ConfigMaps(webhookTestNamespace).Create(ctx, triggerCM, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred(), "ConfigMap creation should succeed — proves API server reached webhook on hybrid node through gateway")
+
+				test.Logger.Info("Webhook connectivity verified — API server reached hybrid node through gateway")
+			})
+		})
+
+		Context("Helm Upgrade", func() {
+			It("should maintain connectivity after helm upgrade", func(ctx context.Context) {
+				testCaseLabels["test-case"] = "helm-upgrade"
+
+				hybridNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, hybridNodeLabelKey, hybridNodeLabelValue, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find hybrid node")
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, hybridNodeName, "default", test.Cluster.Region, test.Logger, "nginx-upgrade", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred())
+
+				cloudNodeName, err := kubernetes.FindNodeWithLabel(ctx, test.K8sClient.Interface, "node.kubernetes.io/instance-type", cloudInstanceType, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "should find cloud node")
+				err = kubernetes.CreateNginxPodInNode(ctx, test.K8sClient.Interface, cloudNodeName, "default", test.Cluster.Region, test.Logger, "client-upgrade", testCaseLabels)
+				Expect(err).NotTo(HaveOccurred())
+
+				test.Logger.Info("Verifying pre-upgrade connectivity")
+				err = kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-upgrade", "nginx-upgrade", "default", test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "pre-upgrade connectivity should work")
+
+				gatewayChart := requireEnv("GATEWAY_CHART")
+				gatewayChartVersion := requireEnv("GATEWAY_CHART_VERSION")
+
+				test.Logger.Info("Running helm upgrade with additional pod CIDR")
+				// Upgrade adds 10.88.0.0/16 to podCIDRs. We verify the upgrade
+				// succeeds and existing connectivity survives; reachability of
+				// the new CIDR is not tested right now but would be good to add in the future.
+				upgradeGatewayChart(ctx, test, gatewayChart, gatewayChartVersion, sharedTestData.GatewayImageURI, sharedTestData.RouteTableIDs, "10.87.0.0/16,10.88.0.0/16")
+
+				test.Logger.Info("Waiting for upgraded pods to be ready")
+				err = kubernetes.WaitForPodsToBeRunning(ctx, test.K8sClient.Interface, metav1.ListOptions{
+					LabelSelector: "app.kubernetes.io/name=eks-hybrid-nodes-gateway",
+				}, gatewayNamespace, test.Logger)
+				Expect(err).NotTo(HaveOccurred(), "upgraded gateway pods should be ready")
+
+				test.Logger.Info("Verifying post-upgrade connectivity")
+				Eventually(func(g Gomega) {
+					err := kubernetes.TestPodToPodConnectivity(ctx, test.K8sClientConfig, test.K8sClient.Interface, "client-upgrade", "nginx-upgrade", "default", test.Logger)
+					g.Expect(err).NotTo(HaveOccurred())
+				}).WithTimeout(3*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "connectivity should work after helm upgrade")
 			})
 		})
 	})

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -1,0 +1,236 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/eks-hybrid/test/e2e/constants"
+	"github.com/aws/eks-hybrid/test/e2e/suite"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	webhookTestNamespace = "webhook-test-gateway"
+	webhookServiceName   = "webhook-svc"
+	webhookPodName       = "webhook-server"
+	webhookConfigName    = "gateway-webhook-test"
+)
+
+func generateWebhookCerts(serviceName, namespace string) (caPEM, certPEM, keyPEM []byte, err error) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generating CA key: %w", err)
+	}
+
+	ca := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "webhook-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating CA cert: %w", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parsing CA cert: %w", err)
+	}
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generating server key: %w", err)
+	}
+
+	server := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: fmt.Sprintf("%s.%s.svc", serviceName, namespace)},
+		DNSNames: []string{
+			serviceName,
+			fmt.Sprintf("%s.%s", serviceName, namespace),
+			fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+			fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, server, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating server cert: %w", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshaling server key: %w", err)
+	}
+
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return
+}
+
+const webhookJS = `function handle(r) {
+    try {
+        var raw = r.requestText || r.requestBody;
+        var body = JSON.parse(raw);
+        var resp = {
+            apiVersion: "admission.k8s.io/v1",
+            kind: "AdmissionReview",
+            response: { uid: body.request.uid, allowed: true }
+        };
+        r.headersOut['Content-Type'] = 'application/json';
+        r.return(200, JSON.stringify(resp));
+    } catch (e) {
+        r.error('webhook error: ' + e.toString() + ' body=' + (r.requestText || r.requestBody || 'NULL'));
+        r.headersOut['Content-Type'] = 'application/json';
+        var errResp = {error: e.toString(), requestBody: (r.requestText || r.requestBody || 'EMPTY').substring(0, 200)};
+        r.return(500, JSON.stringify(errResp));
+    }
+}
+export default { handle };`
+
+const webhookNginxConf = `load_module /etc/nginx/modules/ngx_http_js_module.so;
+events { worker_connections 64; }
+http {
+    js_import webhook from /etc/nginx/conf.d/webhook.js;
+    server {
+        listen 443 ssl;
+        client_body_in_single_buffer on;
+        client_body_buffer_size 64k;
+        client_max_body_size 64k;
+        ssl_certificate /etc/webhook/tls/tls.crt;
+        ssl_certificate_key /etc/webhook/tls/tls.key;
+        location / { js_content webhook.handle; }
+    }
+}`
+
+func deployWebhookOnHybridNode(ctx context.Context, test *suite.PeeredVPCTest) []byte {
+	caPEM, certPEM, keyPEM, err := generateWebhookCerts(webhookServiceName, webhookTestNamespace)
+	Expect(err).NotTo(HaveOccurred(), "should generate webhook TLS certs")
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   webhookTestNamespace,
+		Labels: map[string]string{"gateway-webhook-test": "true"},
+	}}
+	_, err = test.K8sClient.Interface.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "should create webhook test namespace")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook-tls", Namespace: webhookTestNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": certPEM, "tls.key": keyPEM},
+	}
+	_, err = test.K8sClient.Interface.CoreV1().Secrets(webhookTestNamespace).Create(ctx, secret, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "should create TLS secret")
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook-config", Namespace: webhookTestNamespace},
+		Data:       map[string]string{"nginx.conf": webhookNginxConf, "webhook.js": webhookJS},
+	}
+	_, err = test.K8sClient.Interface.CoreV1().ConfigMaps(webhookTestNamespace).Create(ctx, cm, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "should create webhook ConfigMap")
+
+	image := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/ecr-public/nginx/nginx:latest", constants.EcrAccountId, test.Cluster.Region)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookPodName, Namespace: webhookTestNamespace, Labels: map[string]string{"app": "webhook-test"}},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{"eks.amazonaws.com/compute-type": "hybrid"},
+			Tolerations:  []corev1.Toleration{{Key: "eks.amazonaws.com/compute-type", Value: "hybrid", Effect: corev1.TaintEffectNoSchedule}},
+			Containers: []corev1.Container{{
+				Name:    "webhook",
+				Image:   image,
+				Command: []string{"nginx", "-c", "/etc/nginx/custom/nginx.conf", "-g", "daemon off;"},
+				Ports:   []corev1.ContainerPort{{ContainerPort: 443}},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "tls", MountPath: "/etc/webhook/tls", ReadOnly: true},
+					{Name: "config", MountPath: "/etc/nginx/custom/nginx.conf", SubPath: "nginx.conf", ReadOnly: true},
+					{Name: "config", MountPath: "/etc/nginx/conf.d/webhook.js", SubPath: "webhook.js", ReadOnly: true},
+				},
+			}},
+			Volumes: []corev1.Volume{
+				{Name: "tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "webhook-tls"}}},
+				{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "webhook-config"}}}},
+			},
+		},
+	}
+	_, err = test.K8sClient.Interface.CoreV1().Pods(webhookTestNamespace).Create(ctx, pod, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "should create webhook pod")
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookServiceName, Namespace: webhookTestNamespace},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "webhook-test"},
+			Ports:    []corev1.ServicePort{{Port: 443, TargetPort: intstr.FromInt32(443)}},
+		},
+	}
+	_, err = test.K8sClient.Interface.CoreV1().Services(webhookTestNamespace).Create(ctx, svc, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "should create webhook service")
+
+	test.Logger.Info("Waiting for webhook pod to be ready")
+	Eventually(func(g Gomega) {
+		p, pErr := test.K8sClient.Interface.CoreV1().Pods(webhookTestNamespace).Get(ctx, webhookPodName, metav1.GetOptions{})
+		g.Expect(pErr).NotTo(HaveOccurred())
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady {
+				g.Expect(c.Status).To(Equal(corev1.ConditionTrue), "pod should be ready, phase: %s", p.Status.Phase)
+				return
+			}
+		}
+		g.Expect(true).To(BeFalse(), "pod has no Ready condition yet, phase: %s", p.Status.Phase)
+	}).WithTimeout(3*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "webhook pod should become ready")
+
+	return caPEM
+}
+
+func registerValidatingWebhook(ctx context.Context, test *suite.PeeredVPCTest, caPEM []byte) {
+	fail := admissionv1.Fail
+	none := admissionv1.SideEffectClassNone
+	webhook := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookConfigName},
+		Webhooks: []admissionv1.ValidatingWebhook{{
+			Name:                    "gateway-test.eks.amazonaws.com",
+			AdmissionReviewVersions: []string{"v1"},
+			FailurePolicy:           &fail,
+			SideEffects:             &none,
+			TimeoutSeconds:          aws.Int32(10),
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service:  &admissionv1.ServiceReference{Name: webhookServiceName, Namespace: webhookTestNamespace, Path: aws.String("/"), Port: aws.Int32(443)},
+				CABundle: caPEM,
+			},
+			Rules: []admissionv1.RuleWithOperations{{
+				Operations: []admissionv1.OperationType{admissionv1.Create},
+				Rule:       admissionv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"configmaps"}},
+			}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"gateway-webhook-test": "true"}},
+		}},
+	}
+	_, err := test.K8sClient.Interface.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(ctx, webhook, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "should register validating webhook")
+}
+
+func cleanupWebhookTest(ctx context.Context, test *suite.PeeredVPCTest) {
+	test.Logger.Info("Cleaning up webhook test resources")
+	_ = test.K8sClient.Interface.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, webhookConfigName, metav1.DeleteOptions{})
+	_ = test.K8sClient.Interface.CoreV1().Namespaces().Delete(ctx, webhookTestNamespace, metav1.DeleteOptions{})
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds to the end-to-end test suite for the EKS Hybrid Nodes Gateway covering dynamic node lifecycle, webhook connectivity through the gateway, and helm upgrade resilience.

**New Tests:**
- Dynamic node lifecycle: joins a second hybrid node, verifies routing, removes it, confirms original node still works
- Webhook connectivity: deploys a validating webhook on a hybrid node and triggers it from the API server through the gateway
- Helm upgrade: upgrades the release with an additional pod CIDR and verifies existing connectivity survives

**Infrastructure improvements:**
- VXLAN security group rules scoped from 0.0.0.0/0 to specific VPC CIDRs per direction
- Idempotent SG rule creation (ignores InvalidPermission.Duplicate)
- Deduplicated helm install/upgrade logic via shared newHelmConfig() and gatewayHelmValues()
- Deterministic label selector ordering
- Self-managed webhook server (nginx + njs) with generated TLS certs — no cert-manager dependency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
