### PR TITLE
fixing multi arch builds for gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest
 FROM ${BASE_IMAGE}
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY _output/LICENSES /LICENSES
 COPY _output/ATTRIBUTION.txt /ATTRIBUTION.txt


### PR DESCRIPTION
*Description of changes:*
Fixing multi arch builds for gateway

```
NAME                                          ARCH    OS      INSTANCE
i-0bb9c48681c5e63a1                           arm64   linux   c6g.large
i-0bfb9eaed37a3d79e                           arm64   linux   c6g.large
ip-10-226-241-81.us-west-2.compute.internal   amd64   linux   t3.medium
mi-0cf215e6ccce2f917                          amd64   linux   <none>
mi-0eb22c71511369251                          amd64   linux   <none>
Both pods are Running on arm64 nodes (c6g.large). No exec format error. Fix is confirmed.
```

*Testing*
```
═══════════════════════════════════════════════════════════════
CONFORMANT  16/16 passed in 82s
═══════════════════════════════════════════════════════════════
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
