### PR TITLE
fix prod release script with missing env

### DIFF
--- a/hack/prod-release.sh
+++ b/hack/prod-release.sh
@@ -79,6 +79,7 @@ CHART_OCI_REPO="oci://$(dirname "${PUBLIC_ECR_URI}")"
 
 echo "==> Packaging Helm chart (version=${CHART_VERSION}, appVersion=${RELEASE_TAG})"
 make helm-push \
+  REGISTRY="${PUBLIC_ECR_URI}" \
   CHART_REPO="${CHART_OCI_REPO}" \
   CHART_VERSION="${CHART_VERSION}" \
   APP_VERSION="${RELEASE_TAG}"


### PR DESCRIPTION
*Description of changes:*
Fixes bug in release script.

```bash
helm package charts/eks-hybrid-nodes-gateway --version 1.0.0 --app-version v1.0.0
Successfully packaged chart and saved it to: /codebuild/output/src4029704683/src/eks-hybrid-nodes-gateway-1.0.0.tgz
error: REGISTRY is required
make: *** [Makefile:81: helm-push] Error 1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
