### PR TITLE
Helm deployment prefer different AZs and updating readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ helm-lint: ## Lint the Helm chart
 
 helm-template: ## Render Helm templates locally for review
 	helm template eks-hybrid-nodes-gateway $(CHART_DIR) \
-		--set vpcCIDR=10.0.0.0/16 --set podCIDRs=10.86.0.0/16
+		--set vpcCIDR=10.0.0.0/16 --set podCIDRs=10.86.0.0/16 --set routeTableIDs=rtb-example
 
 CHART_VERSION ?=
 APP_VERSION   ?=

--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@ VXLAN gateway for EKS Hybrid Nodes that enables pod-to-pod communication between
 ## Architecture
 
 ```
-┌─── AWS VPC ───────────────────────────────────┐    ┌─── On-Premises ──────────┐
-│                                                │    │                         │
-│  ┌──────────────┐    ┌──────────────┐          │    │  ┌──────────────┐       │
-│  │   Gateway    │    │   Gateway    │          │    │  │ Hybrid Node  │       │
-│  │   (Leader)   │    │  (Standby)   │          │    │  │   (Cilium)   │       │
-│  │              │    │              │          │    │  │              │       │
-│  │ hybrid_vxlan0│    │ hybrid_vxlan0│          │    │  │  cilium_vxlan│       │
-│  └──────┬───────┘    └──────┬───────┘          │    │  └──────┬───────┘       │
-│         │                   │                  │    │         │               │
-│         │  VXLAN (VNI 2, UDP 8472)             │    │         │               │
-│         └───────────┬──────────────────────────┼────┼─────────┘               │
-│                     │                          │    │                         │
-│  VPC Route Table:                              │    │                         │
-│    hybrid-pod-cidr → leader ENI                │    │                         │
-│    (failover → standby ENI)                    │    │                         │
-└────────────────────────────────────────────────┘    └─────────────────────────┘
+┌─── AWS VPC ───────────────────────────────────┐    ┌─── On-Premises ─────────┐
+│                                               │    │                         │
+│  ┌──────────────┐    ┌──────────────┐         │    │  ┌──────────────┐       │
+│  │   Gateway    │    │   Gateway    │         │    │  │ Hybrid Node  │       │
+│  │   (Leader)   │    │  (Standby)   │         │    │  │   (Cilium)   │       │
+│  │              │    │              │         │    │  │              │       │
+│  │ hybrid_vxlan0│    │ hybrid_vxlan0│         │    │  │  cilium_vxlan│       │
+│  └──────┬───────┘    └──────┬───────┘         │    │  └──────┬───────┘       │
+│         │                   │                 │    │         │               │
+│         │  VXLAN (VNI 2, UDP 8472)            │    │         │               │
+│         └───────────┬─────────────────────────┼────┼─────────┘               │
+│                     │                         │    │                         │
+│  VPC Route Table:                             │    │                         │
+│    hybrid-pod-cidr → leader ENI               │    │                         │
+│    (failover → standby ENI)                   │    │                         │
+└───────────────────────────────────────────────┘    └─────────────────────────┘
 ```
 
 **How it works:**
@@ -112,7 +112,7 @@ All configuration is via environment variables or CLI flags:
 | `VPC_CIDR` | `--vpc-cidr` | **required** | Cluster VPC CIDR |
 | `POD_CIDRS` | `--pod-cidrs` | **required** | Comma-separated hybrid pod CIDRs (e.g. `10.250.0.0/16,10.251.0.0/16`) |
 | `LEADER_ELECTION_ID` | `--leader-election-id` | `hybrid-gateway-leader` | Leader election lease name |
-| `ROUTE_TABLE_IDS` | `--route-table-ids` | | Comma-separated VPC route table IDs to program |
+| `ROUTE_TABLE_IDS` | `--route-table-ids` | **required** | Comma-separated VPC route table IDs to program |
 | `AWS_REGION` | `--aws-region` | auto-detected | AWS region (auto-detected from IMDS if not set) |
 | `AWS_INSTANCE_ID` | `--aws-instance-id` | auto-detected | EC2 instance ID (auto-detected from IMDS if not set) |
 | `DEBUG` | `--debug` | `false` | Enable debug logging |

--- a/charts/eks-hybrid-nodes-gateway/templates/deployment.yaml
+++ b/charts/eks-hybrid-nodes-gateway/templates/deployment.yaml
@@ -39,6 +39,13 @@ spec:
                 matchLabels:
                   {{- include "eks-hybrid-nodes-gateway.selectorLabels" . | nindent 18 }}
               topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "eks-hybrid-nodes-gateway.selectorLabels" . | nindent 20 }}
+                topologyKey: topology.kubernetes.io/zone
       tolerations:
         - key: {{ .Values.nodeLabel }}
           operator: Exists

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -31,6 +31,7 @@ make docker-push REGISTRY=${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com TAG=${TAG}
 
 # 2. Package and push the Helm chart
 make helm-push \
+  REGISTRY=${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com \
   CHART_REPO=oci://${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com \
   CHART_VERSION=0.0.0-${TAG} \
   APP_VERSION=${TAG}


### PR DESCRIPTION
*Description of changes:*
Add AZ anti-affinity and fix docs

- Helm chart: add preferred zone anti-affinity to spread gateway pods across AZs
- README/Makefile: mark routeTableIDs as required, fix helm-template and e2e docs


*Testing*
```
make helm-push
```
Built and installed the new helm chart with auto mode.
```
k get nodeclaims.karpenter.sh -A

NAME                   TYPE        CAPACITY    ZONE         NODE                  READY   AGE
hybrid-gateway-rtn54   c6a.large   on-demand   us-west-2a   i-0cbb1f9ac7e0e886a   True    2m53s
hybrid-gateway-zrzpg   c6a.large   on-demand   us-west-2b   i-023013bd83781f58e   True    64m
```
Note: The zone anti-affinity is a scheduling-time preference. Existing pods won't automatically redistribute when new AZs are added.

A `kubectl rollout restart deployment` is needed to trigger rescheduling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
