### PR TITLE
recreate CiliumVTEPConfig if deleted while gateway is running

### DIFF
--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -25,6 +25,6 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.25"
+          go-version-input: "1.26.1"
           check-latest: true
           repo-checkout: false

--- a/charts/eks-hybrid-nodes-gateway/templates/clusterrole.yaml
+++ b/charts/eks-hybrid-nodes-gateway/templates/clusterrole.yaml
@@ -13,4 +13,4 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["cilium.io"]
     resources: ["ciliumvtepconfigs"]
-    verbs: ["get", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update"]

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -205,6 +205,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controller.VTEPConfigReconciler{
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		VxlanIface: vxlanIface,
+		NodeIP:     localIP,
+		VpcCIDRs:   vpcCIDRList,
+		Logger:     logger,
+	}).SetupWithManager(mgr); err != nil {
+		logger.Error(err, "Unable to create VTEPConfig controller")
+		os.Exit(1)
+	}
+
 	healthServer.SetReady(true)
 
 	// Set gateway info metric with static labels

--- a/internal/controller/vtepconfig.go
+++ b/internal/controller/vtepconfig.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"context"
+	"net"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/aws/hybrid-gateway/internal/cilium"
+	"github.com/aws/hybrid-gateway/internal/vxlan"
+)
+
+// VTEPConfigReconciler watches CiliumVTEPConfig and recreates it if deleted.
+type VTEPConfigReconciler struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	VxlanIface *vxlan.Interface
+	NodeIP     net.IP
+	VpcCIDRs   []string
+	Logger     logr.Logger
+}
+
+// Reconcile recreates the CiliumVTEPConfig if it was deleted.
+func (r *VTEPConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if req.Name != cilium.CiliumVTEPConfigName {
+		return ctrl.Result{}, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cilium.io",
+		Version: "v2",
+		Kind:    "CiliumVTEPConfig",
+	})
+
+	err := r.Get(ctx, req.NamespacedName, obj)
+	if client.IgnoreNotFound(err) != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err != nil {
+		// NotFound — recreate it
+		logger.Info("CiliumVTEPConfig deleted, recreating", "name", req.Name)
+		if upsertErr := cilium.UpsertCiliumVTEPConfig(
+			ctx, r.Client, r.VxlanIface, r.NodeIP, r.VpcCIDRs, r.Logger,
+		); upsertErr != nil {
+			logger.Error(upsertErr, "Failed to recreate CiliumVTEPConfig")
+			return ctrl.Result{}, upsertErr
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Exists — nothing to do
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the controller. Leader-only.
+func (r *VTEPConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	vtepConfig := &unstructured.Unstructured{}
+	vtepConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cilium.io",
+		Version: "v2",
+		Kind:    "CiliumVTEPConfig",
+	})
+
+	leaderElectionRequired := true
+	return ctrl.NewControllerManagedBy(mgr).
+		For(vtepConfig).
+		WithOptions(controller.Options{
+			NeedLeaderElection: &leaderElectionRequired,
+		}).
+		Complete(r)
+}


### PR DESCRIPTION

***Description of changes:***
The leader only upserts CiliumVTEPConfig once during startup. If the CR is manually deleted while the gateway is running, it is never recreated, breaking VPC-to-hybrid traffic until pods are restarted.

Added a controller that watches CiliumVTEPConfig and recreates it if deleted. Also adds list/watch RBAC verbs to the ClusterRole (required for the controller's informer to establish the watch connection).

Testing:
- Deployed gateway to test cluster with updated Helm chart
- Verified CiliumVTEPConfig was created and READY
- Deleted CR: kubectl delete ciliumvtepconfig hybrid-gateway
- Confirmed CR was recreated within 2 seconds 

