### PR TITLE
recreate CiliumVTEPConfig if deleted while gateway is running

### DIFF
--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -25,6 +25,6 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.25"
+          go-version-input: "1.26.1"
           check-latest: true
           repo-checkout: false

--- a/charts/eks-hybrid-nodes-gateway/templates/clusterrole.yaml
+++ b/charts/eks-hybrid-nodes-gateway/templates/clusterrole.yaml
@@ -13,4 +13,4 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["cilium.io"]
     resources: ["ciliumvtepconfigs"]
-    verbs: ["get", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update"]

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -11,14 +11,21 @@ import (
 	"time"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/aws/hybrid-gateway/internal/aws"
+	"github.com/aws/hybrid-gateway/internal/cilium"
 	"github.com/aws/hybrid-gateway/internal/controller"
 	"github.com/aws/hybrid-gateway/internal/gateway"
 	"github.com/aws/hybrid-gateway/internal/health"
@@ -155,6 +162,13 @@ func main() {
 		logger.Info("Route table manager ready", "routeTables", rtIDs, "region", awsRegion)
 	}
 
+	vtepCacheObject := &unstructured.Unstructured{}
+	vtepCacheObject.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cilium.io",
+		Version: "v2",
+		Kind:    "CiliumVTEPConfig",
+	})
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                server.Options{BindAddress: metricsAddr},
@@ -164,6 +178,16 @@ func main() {
 		LeaseDuration:          &leaseDuration,
 		RenewDeadline:          &renewDeadline,
 		RetryPeriod:            &retryPeriod,
+		Cache: cache.Options{
+			SyncPeriod: ptr.To(1 * time.Hour),
+			ByObject: map[client.Object]cache.ByObject{
+				vtepCacheObject: {
+					Field: fields.SelectorFromSet(fields.Set{
+						"metadata.name": cilium.CiliumVTEPConfigName,
+					}),
+				},
+			},
+		},
 	})
 	if err != nil {
 		logger.Error(err, "Unable to create manager")
@@ -202,6 +226,18 @@ func main() {
 		VTEP:   vtep,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "Unable to create Node controller")
+		os.Exit(1)
+	}
+
+	if err = (&controller.VTEPConfigReconciler{
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		VxlanIface: vxlanIface,
+		NodeIP:     localIP,
+		VpcCIDRs:   vpcCIDRList,
+		Logger:     logger,
+	}).SetupWithManager(mgr); err != nil {
+		logger.Error(err, "Unable to create VTEPConfig controller")
 		os.Exit(1)
 	}
 

--- a/internal/cilium/vtep.go
+++ b/internal/cilium/vtep.go
@@ -85,6 +85,10 @@ func UpsertCiliumVTEPConfig(
 		desired.SetGroupVersionKind(ciliumVTEPConfigGVK)
 		desired.SetCreationTimestamp(metav1.Time{})
 		if createErr := k8sClient.Create(ctx, desired); createErr != nil {
+			if k8serrors.IsAlreadyExists(createErr) {
+				logger.Info("CiliumVTEPConfig already exists", "name", CiliumVTEPConfigName)
+				return nil
+			}
 			return fmt.Errorf("creating CiliumVTEPConfig %q: %w", CiliumVTEPConfigName, createErr)
 		}
 		logger.Info("Created CiliumVTEPConfig", "name", CiliumVTEPConfigName)

--- a/internal/controller/vtepconfig.go
+++ b/internal/controller/vtepconfig.go
@@ -1,0 +1,63 @@
+package controller
+
+import (
+	"context"
+	"net"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/aws/hybrid-gateway/internal/cilium"
+	"github.com/aws/hybrid-gateway/internal/vxlan"
+)
+
+// VTEPConfigReconciler watches CiliumVTEPConfig and recreates it if deleted
+// or corrects its values if they don't match the leader's current state.
+type VTEPConfigReconciler struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	VxlanIface *vxlan.Interface
+	NodeIP     net.IP
+	VpcCIDRs   []string
+	Logger     logr.Logger
+}
+
+// Reconcile calls UpsertCiliumVTEPConfig which handles both deletion and value correction.
+func (r *VTEPConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if req.Name != cilium.CiliumVTEPConfigName {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Reconciling CiliumVTEPConfig", "name", req.Name)
+	if err := cilium.UpsertCiliumVTEPConfig(ctx, r.Client, r.VxlanIface, r.NodeIP, r.VpcCIDRs, r.Logger); err != nil {
+		logger.Error(err, "Failed to upsert CiliumVTEPConfig")
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the controller. Leader-only.
+func (r *VTEPConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	vtepConfig := &unstructured.Unstructured{}
+	vtepConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cilium.io",
+		Version: "v2",
+		Kind:    "CiliumVTEPConfig",
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(vtepConfig).
+		WithOptions(controller.Options{
+			NeedLeaderElection: ptr.To(true),
+		}).
+		Complete(r)
+}

--- a/internal/controller/vtepconfig_test.go
+++ b/internal/controller/vtepconfig_test.go
@@ -1,0 +1,96 @@
+package controller_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/hybrid-gateway/internal/cilium"
+	"github.com/aws/hybrid-gateway/internal/controller"
+	"github.com/aws/hybrid-gateway/internal/vxlan"
+)
+
+const (
+	testNodeIP  = "10.0.2.99"
+	testMAC     = "02:00:0a:00:02:63"
+	testVPCCIDR = "10.0.0.0/16"
+)
+
+var vtepGVK = schema.GroupVersionKind{
+	Group:   "cilium.io",
+	Version: "v2",
+	Kind:    "CiliumVTEPConfig",
+}
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(vtepGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group:   "cilium.io",
+		Version: "v2",
+		Kind:    "CiliumVTEPConfigList",
+	}, &unstructured.UnstructuredList{})
+	return scheme
+}
+
+func TestVTEPConfigReconciler_IgnoresOtherNames(t *testing.T) {
+	scheme := newTestScheme()
+	r := &controller.VTEPConfigReconciler{
+		Client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:     scheme,
+		VxlanIface: vxlan.NewInterfaceWithMAC(testMAC),
+		NodeIP:     net.ParseIP(testNodeIP),
+		VpcCIDRs:   []string{testVPCCIDR},
+		Logger:     logr.Discard(),
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "some-other-config"},
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestVTEPConfigReconciler_RecreatesWhenDeleted(t *testing.T) {
+	scheme := newTestScheme()
+	r := &controller.VTEPConfigReconciler{
+		Client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:     scheme,
+		VxlanIface: vxlan.NewInterfaceWithMAC(testMAC),
+		NodeIP:     net.ParseIP(testNodeIP),
+		VpcCIDRs:   []string{testVPCCIDR},
+		Logger:     logr.Discard(),
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cilium.CiliumVTEPConfigName},
+	})
+
+	assert.NoError(t, err)
+
+	// Verify Reconcile wired through to Upsert and the CR exists
+	created := &unstructured.Unstructured{}
+	created.SetGroupVersionKind(vtepGVK)
+	err = r.Get(context.Background(), types.NamespacedName{Name: cilium.CiliumVTEPConfigName}, created)
+	require.NoError(t, err)
+
+	endpoints, found, err := unstructured.NestedSlice(created.Object, "spec", "endpoints")
+	require.NoError(t, err)
+	require.True(t, found, "spec.endpoints not found")
+	require.Len(t, endpoints, 1)
+
+	ep := endpoints[0].(map[string]interface{})
+	assert.Equal(t, testNodeIP, ep["tunnelEndpoint"])
+	assert.Equal(t, testMAC, ep["mac"])
+	assert.Equal(t, testVPCCIDR, ep["cidr"])
+}


### PR DESCRIPTION
**Issue** 
https://github.com/aws/eks-hybrid-nodes-gateway/issues/23
Description of changes:
The leader only upserts CiliumVTEPConfig once during startup. If the CR is manually deleted while the gateway is running, it is never recreated, breaking VPC-to-hybrid traffic until pods are restarted.

Added a controller that watches CiliumVTEPConfig and recreates or corrects it if deleted or modified . Also adds list/watch RBAC verbs to the ClusterRole (required for the controller's informer to establish the watch connection).

bump govulncheck go version to 1.26.1 
Testing:

    Deployed gateway to test cluster with updated Helm chart
    Verified CiliumVTEPConfig was created and READY
    Deleted CR: kubectl delete ciliumvtepconfig hybrid-gateway
    Confirmed CR was recreated within 2 seconds
