### PR TITLE
wait for MNG deletion in e2e cleanup to prevent CFN stack delete fail…

### DIFF
--- a/test/e2e/gateway_suite_test.go
+++ b/test/e2e/gateway_suite_test.go
@@ -262,6 +262,12 @@ func createMNG(ctx context.Context, test *suite.PeeredVPCTest, name string, desi
 			ClusterName:   aws.String(test.Cluster.Name),
 			NodegroupName: aws.String(name),
 		})
+		test.Logger.Info("Waiting for MNG deletion", "name", name)
+		deleteWaiter := eks.NewNodegroupDeletedWaiter(test.EKSClient)
+		_ = deleteWaiter.Wait(ctx, &eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(test.Cluster.Name),
+			NodegroupName: aws.String(name),
+		}, 10*time.Minute)
 	})
 }
 


### PR DESCRIPTION


*Issue #, if available:*
The e2e cleanup deletes MNGs then immediately deletes the CloudFormation stack. If the MNG hasn't fully deleted yet, the stack deletion fails with
```
ERROR   failed while waiting for stack operation to stabilize, proceeding with deletion {"stackName": "EKSHybridCI-gateway-e2e-1-31-1783460111", "error": "stack EKSHybridCI-gateway-e2e-1-31-1783460111 failed with status: DELETE_FAILED. Potential root cause: [DELETE_FAILED for ManagedNodeInstanceRole: Cannot delete entity, must remove roles from instance profile first. (Service: Iam, Status Code: 409, Request ID: 518956fc-32d4-4482-893c-6a74c9bf6402) (SDK Attempt Count: 1)]"}
2026-07-07T22:16:12.820Z    INFO    Deleting hybrid nodes cfn stack with deletion mode  {"stackName": "EKSHybridCI-gateway-e2e-1-31-1783460111", "deletionMode": "FORCE_DELETE_STACK"}
Starting stack wait: EKSHybridCI-gateway-e2e-1-31-1783460111 (timeout: 15m0s)
  ·[38;5;214m[TIMEDOUT] in [DeferCleanup (Suite)] - /go/pkg/mod/github.com/aws/eks-hybrid@v1.0.17/test/e2e/suite/peered_vpc.go:391 ·[38;5;243m@ 07/07/26 22:18:36.33
2026-07-07T22:18:36.331Z    ERROR   failed while waiting for stack operation to stabilize, proceeding with deletion {"stackName": "EKSHybridCI-gateway-e2e-1-31-1783460111", "error": "context canceled"}
2026-07-07T22:18:36.331Z    ERROR   ·[38;5;9m
·[38;5;243m/go/pkg/mod/github.com/aws/eks-hybrid@v1.0.17/test/e2e/suite/peered_vpc.go:411
  should teardown e2e resources
  Expected success, but got an error:
      <*fmt.wrapError | 0xc000aee7c0>:
      deleting hybrid nodes cfn stack: describing hybrid nodes cfn stack before
  deletion: operation error CloudFormation: DescribeStacks, context canceled
      {
          msg: "deleting hybrid nodes cfn stack: describing hybrid nodes cfn
  stack before deletion: operation error CloudFormation: DescribeStacks, context
  canceled",
          err: <*fmt.wrapError | 0xc000aee7a0>{
              msg: "describing hybrid nodes cfn stack before deletion: operation
  error CloudFormation: DescribeStacks, context canceled",
              err: <*smithy.OperationError | 0xc00098a330>{
                  ServiceID: "CloudFormation",
                  OperationName: "DescribeStacks",
                  Err: <*errors.errorString | 0x6ea3120>{
                      s: "context canceled",
                  },
              },
          },
      }
```

*Description of changes:*

Add NewNodegroupDeletedWaiter.Wait() (10min timeout) after DeleteNodegroup in DeferCleanup, ensuring the MNG 
is fully gone before stack teardown begins.
